### PR TITLE
Optimize startswith

### DIFF
--- a/testflows/_core/cli/arg/handlers/report/srs_coverage.py
+++ b/testflows/_core/cli/arg/handlers/report/srs_coverage.py
@@ -34,7 +34,7 @@ def color_primary():
 
 
 def result_priority(result):
-    if result.startswith("X"):
+    if result[0] == "X":
         return 2
     elif result == "OK":
         return 1
@@ -45,7 +45,7 @@ def result_priority(result):
 
 
 def color_result(result):
-    if result.startswith("X"):
+    if result[0] == "X":
         return functools.partial(color, color="blue", attrs=["bold"])
     elif result == "OK":
         return functools.partial(color, color="green", attrs=["bold"])

--- a/testflows/_core/contrib/markdown2/markdown2.py
+++ b/testflows/_core/contrib/markdown2/markdown2.py
@@ -1359,7 +1359,7 @@ class Markdown(object):
             link_text = text[start_idx+1:p]
 
             # Possibly a footnote ref?
-            if "footnotes" in self.extras and link_text.startswith("^"):
+            if "footnotes" in self.extras and link_text[0] == "^":
                 normed_id = re.sub(r'\W', '-', link_text[1:])
                 if normed_id in self.footnotes:
                     self.footnote_ids.append(normed_id)
@@ -2671,7 +2671,7 @@ def main(argv=None):
         try:
             for i, line in enumerate(f.readlines()):
                 if not line.strip(): continue
-                if line.lstrip().startswith("#"): continue
+                if line.lstrip()[0] == "#": continue
                 try:
                     pat, href = line.rstrip().rsplit(None, 1)
                 except ValueError:

--- a/testflows/_core/objects.py
+++ b/testflows/_core/objects.py
@@ -1159,7 +1159,7 @@ class Args(dict):
 
     def __call__(self, func):
         for k, v in self.items():
-            if not k.startswith("_"):
+            if not k[0] == "_":
                 setattr(func, k, v)
         return func
 

--- a/testflows/_core/parallel/service.py
+++ b/testflows/_core/parallel/service.py
@@ -1018,7 +1018,7 @@ def auto_expose(obj):
     properties = []
 
     for name, value in inspect.getmembers(obj):
-        if name.startswith("_"):
+        if name[0] == "_":
             continue
 
         if type(value) in [

--- a/testflows/_core/test.py
+++ b/testflows/_core/test.py
@@ -349,7 +349,7 @@ class Context(object):
 
     def __getattr__(self, name):
         try:
-            if name.startswith("_"):
+            if name[0] == "_":
                 return self.__dict__[name]
         except KeyError:
             raise AttributeError(name) from None
@@ -365,7 +365,7 @@ class Context(object):
                 raise AttributeError(name) from None
 
     def __setattr__(self, name, value):
-        if name.startswith("_"):
+        if name[0] == "_":
             self.__dict__[name] = value
         else:
             self._state[name] = value
@@ -377,7 +377,7 @@ class Context(object):
             raise AttributeError(name) from None
 
     def __contains__(self, name):
-        if name.startswith("_"):
+        if name[0] == "_":
             return name in self.__dict__
 
         curr = self
@@ -2240,7 +2240,7 @@ class TestDefinition(object):
                     ),
                 )
                 kwargs["args"].update(
-                    {k: v for k, v in cli_args.items() if not k.startswith("_")}
+                    {k: v for k, v in cli_args.items() if k[0] != "_"}
                 )
                 if settings.profile:
                     self.profiler = cProfile.Profile()

--- a/testflows/_core/transform/log/brisk.py
+++ b/testflows/_core/transform/log/brisk.py
@@ -54,7 +54,7 @@ def color_other(other):
 def color_result(result, attrs=None, retry=False):
     if attrs is None:
         attrs = ["bold"]
-    if result.startswith("X"):
+    if result[0] == "X":
         return functools.partial(color, color="blue", attrs=attrs)
     elif result == "OK":
         return functools.partial(color, color="green", attrs=attrs)

--- a/testflows/_core/transform/log/classic.py
+++ b/testflows/_core/transform/log/classic.py
@@ -59,7 +59,7 @@ def color_result(result, icon=None):
 
     if icon is None:
         icon = result_icon(result)
-    if result.startswith("X"):
+    if result[0] == "X":
         return color(icon, "blue", attrs=["bold"])
     elif result == "OK":
         return color(icon, "green", attrs=["bold"])
@@ -144,7 +144,7 @@ def format_result(msg):
         out += f" {_test}"
         if _result_message:
             out += f"\n{indent}  {color(format_multiline(_result_message, indent).lstrip(), 'yellow', attrs=['bold'])}"
-    elif result.startswith("X"):
+    elif result[0] == "X":
         out += f" {_test}"
         if msg["result_reason"]:
             out += f"\n{indent}  {color(msg['result_reason'], 'blue', attrs=['bold'])}"

--- a/testflows/_core/transform/log/dots.py
+++ b/testflows/_core/transform/log/dots.py
@@ -24,7 +24,7 @@ count = 0
 
 
 def color_result(result):
-    if result.startswith("X"):
+    if result[0] == "X":
         return color(".", "blue", attrs=["bold"])
     elif result == "OK":
         return color(".", "green", attrs=["bold"])

--- a/testflows/_core/transform/log/fails.py
+++ b/testflows/_core/transform/log/fails.py
@@ -62,7 +62,7 @@ def color_result(result, icon=None):
 
     if icon is None:
         icon = result_icon(result)
-    if result.startswith("X"):
+    if result[0] == "X":
         return color(icon, "blue", attrs=["bold"])
     elif result == "OK":
         return color(icon, "green", attrs=["bold"])
@@ -207,7 +207,7 @@ def format_result(
         if _result_message:
             out += f"\n{indent}  {color(format_multiline(_result_message, indent).lstrip(), 'yellow', attrs=['bold'])}"
         out += "\n"
-    elif not only_new and result.startswith("X"):
+    elif not only_new and result[0] == "X":
         out += f" {_test}"
         if msg["result_reason"]:
             out += f"\n{indent}  {color(msg['result_reason'], 'blue', attrs=['bold'])}"

--- a/testflows/_core/transform/log/fails.py
+++ b/testflows/_core/transform/log/fails.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import textwrap
 import functools
+import re
 
 import testflows.settings as settings
 
@@ -259,10 +260,12 @@ def transform(
                 if not test_id in buffer:
                     buffer[test_id] = []
 
-                for _t in skip_for_buffer[0]:
-                    if test_id.startswith(_t + sep):
-                        skip = True
-                        break
+                pattern = re.compile(
+                    r"|".join(re.escape(_t + sep) for _t in skip_for_buffer[0])
+                )
+                if pattern.match(test_id):
+                    skip = True
+
                 if not skip:
                     buffer[test_id].append(line)
 

--- a/testflows/_core/transform/log/flat.py
+++ b/testflows/_core/transform/log/flat.py
@@ -49,7 +49,7 @@ def color_test_name(name, no_colors=False):
 def color_result(result, attrs=None, no_colors=False, retry=False):
     if attrs is None:
         attrs = ["bold"]
-    if result.startswith("X"):
+    if result[0] == "X":
         return functools.partial(color, color="blue", attrs=attrs, no_colors=no_colors)
     elif result == "OK":
         return functools.partial(color, color="green", attrs=attrs, no_colors=no_colors)
@@ -438,7 +438,7 @@ def format_result(msg, no_colors=False):
         if msg["result_message"]:
             out += color_test_name(",", no_colors=no_colors)
             out += f" {_color(format_multiline(msg['result_message'], _indent).lstrip(), no_colors=no_colors)}"
-    elif result.startswith("X"):
+    elif result[0] == "X":
         out += f" {_test}"
         if msg["result_reason"]:
             out += color_test_name(",", no_colors=no_colors)

--- a/testflows/_core/transform/log/manual.py
+++ b/testflows/_core/transform/log/manual.py
@@ -64,7 +64,7 @@ def color_test_name(name, no_colors=False):
 def color_result(result, attrs=None, no_colors=False, retry=False):
     if attrs is None:
         attrs = ["bold"]
-    if result.startswith("X"):
+    if result[0] == "X":
         return functools.partial(color, color="blue", attrs=attrs, no_colors=no_colors)
     elif result == "OK":
         return functools.partial(color, color="green", attrs=attrs, no_colors=no_colors)
@@ -470,7 +470,7 @@ def format_result(msg, no_colors=False):
         if _result_message:
             out += color_test_name(",", no_colors=no_colors)
             out += f" {_color(format_multiline(_result_message, _indent).lstrip(), no_colors=no_colors)}"
-    elif result.startswith("X"):
+    elif result[0] == "X":
         if msg["result_reason"]:
             out += color_test_name(",", no_colors=no_colors)
             out += f" {_color(msg['result_reason'], no_colors=no_colors)}"

--- a/testflows/_core/transform/log/nice.py
+++ b/testflows/_core/transform/log/nice.py
@@ -56,7 +56,7 @@ def color_prefix(prefix):
 def color_result(result, attrs=None, retry=False):
     if attrs is None:
         attrs = ["bold"]
-    if result.startswith("X"):
+    if result[0] == "X":
         return functools.partial(color, color="blue", attrs=attrs)
     elif result == "OK":
         return functools.partial(color, color="green", attrs=attrs)

--- a/testflows/_core/transform/log/plain.py
+++ b/testflows/_core/transform/log/plain.py
@@ -52,7 +52,7 @@ def color_other(other):
 def color_result(result, attrs=None, retry=False):
     if attrs is None:
         attrs = ["bold"]
-    if result.startswith("X"):
+    if result[0] == "X":
         return functools.partial(color, color="blue", attrs=attrs)
     elif result == "OK":
         return functools.partial(color, color="green", attrs=attrs)

--- a/testflows/_core/transform/log/quiet.py
+++ b/testflows/_core/transform/log/quiet.py
@@ -42,7 +42,7 @@ def color_other(other):
 def color_result(result, attrs=None, retry=False):
     if attrs is None:
         attrs = ["bold"]
-    if result.startswith("X"):
+    if result[0] == "X":
         return functools.partial(color, color="blue", attrs=attrs)
     elif result == "OK":
         return functools.partial(color, color="green", attrs=attrs)
@@ -100,7 +100,7 @@ def format_result(msg, prefix):
 
     result = msg["result_type"]
 
-    if result in ("OK", "Skip") or result.startswith("X"):
+    if result in ("OK", "Skip") or result[0] == "X":
         return
 
     _color = color_result(result)

--- a/testflows/_core/transform/log/report/fails.py
+++ b/testflows/_core/transform/log/report/fails.py
@@ -27,7 +27,7 @@ indent = " " * 2
 def color_result(result, attrs=None):
     if attrs is None:
         attrs = ["bold"]
-    if result.startswith("X"):
+    if result[0] == "X":
         return functools.partial(color, color="blue", attrs=attrs)
     elif result == "OK":
         return functools.partial(color, color="green", attrs=attrs)
@@ -49,7 +49,7 @@ def add_result(msg, results):
     result = msg["result_type"]
 
     if getattr(TestType, msg["test_type"]) < TestType.Iteration:
-        if not result.startswith("X"):
+        if not result[0] == "X":
             return
     if flags & SKIP and settings.show_skipped is False:
         return
@@ -87,7 +87,7 @@ def generate(results, divider, only_new=False):
         )
         out += "\n"
 
-        if result.startswith("X"):
+        if result[0] == "X":
             if not only_new:
                 xfails += out
         else:

--- a/testflows/_core/transform/log/report/passing.py
+++ b/testflows/_core/transform/log/report/passing.py
@@ -28,7 +28,7 @@ indent = " " * 2
 def color_result(result, attrs=None):
     if attrs is None:
         attrs = ["bold"]
-    if result.startswith("X"):
+    if result[0] == "X":
         return functools.partial(color, color="blue", attrs=attrs)
     elif result == "OK":
         return functools.partial(color, color="green", attrs=attrs)

--- a/testflows/_core/transform/log/report/totals.py
+++ b/testflows/_core/transform/log/report/totals.py
@@ -26,7 +26,7 @@ def color_line(line):
 
 
 def color_result(result, text):
-    if result.startswith("X"):
+    if result[0] == "X":
         return color(text, "blue", attrs=["bold"])
     elif result == "OK":
         return color(text, "green", attrs=["bold"])

--- a/testflows/_core/transform/log/short.py
+++ b/testflows/_core/transform/log/short.py
@@ -57,7 +57,7 @@ def color_test_name(name, no_colors=False, use_full_testname=False):
 def color_result(result, attrs=None, no_colors=False, retry=False):
     if attrs is None:
         attrs = ["bold"]
-    if result.startswith("X"):
+    if result[0] == "X":
         return functools.partial(color, color="blue", attrs=attrs, no_colors=no_colors)
     elif result == "OK":
         return functools.partial(color, color="green", attrs=attrs, no_colors=no_colors)
@@ -463,7 +463,7 @@ def format_result(msg, no_colors=False, use_indent=False, use_full_testname=Fals
         if _result_message:
             out += color_test_name(",", no_colors=no_colors)
             out += f" {_color(format_multiline(_result_message, _indent).lstrip(), no_colors=no_colors)}"
-    elif result.startswith("X"):
+    elif result[0] == "X":
         out += f" {_test}"
         if msg["result_reason"]:
             out += color_test_name(",", no_colors=no_colors)

--- a/testflows/_core/transform/log/slick.py
+++ b/testflows/_core/transform/log/slick.py
@@ -56,7 +56,7 @@ def color_result(result):
             return "\u2718"
 
     icon = result_icon(result)
-    if result.startswith("X"):
+    if result[0] == "X":
         return color(icon, "blue", attrs=["bold"])
     elif result == "OK":
         return color(icon, "green", attrs=["bold"])
@@ -200,7 +200,7 @@ def format_result(msg, last_test_id):
         if _result_message:
             out += color_test_name(",")
             out += f" {color(format_multiline(_result_message, _indent).lstrip(), 'yellow', attrs=['bold'])}"
-    elif result.startswith("X"):
+    elif result[0] == "X":
         out += f" {_test}"
         if msg["result_reason"]:
             out += color_test_name(",")


### PR DESCRIPTION
## Contributor License Agreement

For more information see https://github.com/testflows/TestFlows/blob/master/CONTRIBUTING.md.

> *You can electronically sign the CLA inside your first pull request using CLA Assistant by reading the CLA
> and, when requested, sign it by adding a comment containing the following text.*
> 
> `I have read the CLA Document and I hereby sign the CLA`

I, the Contributor, have agreed to and signed the CLA.

* [x] https://github.com/testflows/TestFlows/blob/master/cla/individual_esign_v1.md

## Description of Changes

*Please describe here your proposed changes.*

1. Optimized single-character calls to `startswith`. Small performance improvement.
2. Replaced `startswith` in `fails.py transform` with regex. Reduced run time of `transform nice-new-fails` by ~85%

before
```
time tfs transform nice-new-fails raw\(28\).log > /dev/null

real	0m13.005s
user	0m12.740s
sys	0m0.262s
```

after
```
time tfs transform nice-new-fails raw\(28\).log > /dev/null

real	0m1.919s
user	0m1.886s
sys	0m0.033s
```
