### PR TITLE
revert use of regex for startswith

### DIFF
--- a/testflows/_core/transform/log/fails.py
+++ b/testflows/_core/transform/log/fails.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import textwrap
 import functools
-import re
 
 import testflows.settings as settings
 
@@ -227,7 +226,6 @@ formatters = {
     Message.RESULT.name: (format_result,),
 }
 
-
 def transform(
     brisk=False, plain=False, nice=False, pnice=False, only_new=False, show_input=True
 ):
@@ -260,11 +258,10 @@ def transform(
                 if not test_id in buffer:
                     buffer[test_id] = []
 
-                pattern = re.compile(
-                    r"|".join(re.escape(_t + sep) for _t in skip_for_buffer[0])
-                )
-                if pattern.match(test_id):
-                    skip = True
+                for _t in skip_for_buffer[0]:
+                    if test_id.startswith(_t + sep):
+                        skip = True
+                        break
 
                 if not skip:
                     buffer[test_id].append(line)


### PR DESCRIPTION
## Contributor License Agreement

For more information see https://github.com/testflows/TestFlows/blob/master/CONTRIBUTING.md.

> *You can electronically sign the CLA inside your first pull request using CLA Assistant by reading the CLA
> and, when requested, sign it by adding a comment containing the following text.*
> 
> `I have read the CLA Document and I hereby sign the CLA`

I, the Contributor, have agreed to and signed the CLA.

* [x] https://github.com/testflows/TestFlows/blob/master/cla/individual_esign_v1.md

## Description of Changes

Revert use of regex for startswith. Was not working as expected and once fixed is not faster than startswith.
